### PR TITLE
Update to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.webjars</groupId>
     <artifactId>bootstrap</artifactId>
     <name>Bootstrap</name>
-    <version>2.2.2-2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>WebJar for Bootstrap</description>
     <url>http://webjars.org</url>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.0</version>
         </dependency>
     </dependencies>
 
@@ -49,8 +49,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>2.2.2</upstreamVersion>
-        <sourceUrl>https://github.com/twitter/bootstrap/raw/811b559d36f2ad78c0fc431f6d52dc0e1053c95d/assets</sourceUrl>
+        <upstreamVersion>2.3.0</upstreamVersion>
+        <!-- upstreamSha is the commit on the gh-pages branch where the version is bumped: https://github.com/twitter/bootstrap/commits/gh-pages -->
+        <upstreamSha>91b92f9dd09c1794d02c6157daba5405d8f09e39</upstreamSha>
+        <sourceUrl>https://github.com/twitter/bootstrap/raw/${upstreamSha}/assets</sourceUrl>
         <lessUrl>https://github.com/twitter/bootstrap/archive</lessUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>


### PR DESCRIPTION
Other changes:

Updated to jquery 1.9.0 because Bootstrap did.
Introduced `upstreamSha` variable and a comment explaining how to find it.

Note: make sure to do a mvn clean, as mvn install alone might leave the 2.2.2 folder in the JAR.
