### PR TITLE
Automated download of jQuery whenever bootstrap is requested

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
                 <version>2.3.2</version>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <targetPath>${destDir}</targetPath>
+            </resource>
+        </resources>
     </build>
 
 </project>

--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,0 +1,8 @@
+/*global requirejs */
+
+// Ensure any request for this webjar brings in jQuery.
+requirejs.config({
+    shim: {
+        bootstrap: [ 'webjars!jquery.js' ]
+    }
+});


### PR DESCRIPTION
Shimmed things so that jQuery is loaded as a dependency whenever bootstrap is requested as a module.

I think that this artifact should be released along the lines of version 2.3.1-1 i.e. no special designator is required IMHO. 2.3.1 reflects the bootstrap version (which is still the latest).

Thanks!
