### PR TITLE
Add separate unminified js files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
                                     <fileset dir="${project.build.directory}/bootstrap-${upstreamVersion}/dist" includes="js/,css/,fonts/" />
-                                    <fileset dir="${project.build.directory}/bootstrap-${upstreamVersion}/" includes="less/" />
+                                    <fileset dir="${project.build.directory}/bootstrap-${upstreamVersion}/" includes="js/,less/" excludes="js/tests/" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Right now we can not use a specific `.js` file, we only can add the whole `bootstrap(.min).js` - which gives us a lot of overhead when e.g. we only need the modal dialog component.
Even bootstrap lets us [download a customized js file](http://getbootstrap.com/customize/#plugins).