### PR TITLE
Medium severity vulnerability CVE-2019-11358 in jquery-3.0.0.js

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.0.0</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
Medium severity vulnerability CVE-2019-11358 in jquery-3.0.0.js
Affected versions of this package are vulnerable to Prototype Pollution. The extend function can be tricked into modifying the prototype of Object when the attacker controls part of the structure passed to this function. This can let an attacker add or modify an existing property that will then exist on all objects.
*Update Jquery to 3.4.0