### PR TITLE
Bump to 4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.webjars</groupId>
     <artifactId>bootstrap</artifactId>
     <name>Bootstrap</name>
-    <version>4.4.1-2-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>WebJar for Bootstrap</description>
     <url>http://webjars.org</url>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>popper.js</artifactId>
-            <version>1.14.3</version>
+            <version>1.16.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Also bump popper to 1.16.0 and jQuery to 3.5.1 (as advertised by Bootstrap).